### PR TITLE
Build env update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem "rdiscount"
 gem "builder"
 gem "systemu"
 gem "rack"
+Encoding.default_external = Encoding::UTF_8
+Encoding.default_internal = Encoding::UTF_8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,3 @@ DEPENDENCIES
   rack
   rdiscount
   systemu
-
-BUNDLED WITH
-   1.10.2

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Zeroth, install prerequisites:
 
 First, clone this codebase
 
-	$ git clone git@github.com/tautology-art/tautology.io
+	$ git clone git@github.com:tautology-art/tautology.io
 
-Second, accept the RVM version and gemset, building Ruby 1.9.2 if you need
+Second, accept the RVM version and gemset, building Ruby 1.9.3 if you need
 
-	$ rvm install ruby-1.9.2-p180
+	$ rvm install ruby-1.9.3-p551
 
 Finally, install Bundler and the rest of the gemset
 


### PR DESCRIPTION
I updated README with a new version of Ruby to match the value already set in .ruby-version.

I changed the git clone URI because it didn't work for me with a slash after the domain name. I needed to use a colon.

I'm not sure why Gemfile.lock or the last line of README changed.
